### PR TITLE
Changed prepend of CMAKE_MODULE_PATH to append behaviour

### DIFF
--- a/cmake/cmake_modules-extras.cmake.develspace.in
+++ b/cmake/cmake_modules-extras.cmake.develspace.in
@@ -1,2 +1,2 @@
-# Prepend cmake modules from source directory to the cmake module path
-list(INSERT CMAKE_MODULE_PATH 0 "@CMAKE_CURRENT_SOURCE_DIR@/cmake/Modules")
+# Append cmake modules from source directory to the cmake module path
+list(APPEND CMAKE_MODULE_PATH "@CMAKE_CURRENT_SOURCE_DIR@/cmake/Modules")

--- a/cmake/cmake_modules-extras.cmake.installspace.in
+++ b/cmake/cmake_modules-extras.cmake.installspace.in
@@ -1,2 +1,2 @@
-# Prepend the installed cmake modules to the cmake module path
-list(INSERT CMAKE_MODULE_PATH 0 "${cmake_modules_DIR}/../../../@CATKIN_PACKAGE_SHARE_DESTINATION@/cmake/Modules")
+# Append the installed cmake modules to the cmake module path
+list(APPEND CMAKE_MODULE_PATH "${cmake_modules_DIR}/../../../@CATKIN_PACKAGE_SHARE_DESTINATION@/cmake/Modules")


### PR DESCRIPTION
Changed prepend of CMAKE_MODULE_PATH to append behaviour in order to allow prepending of external CMake modules.
