### PR TITLE
Update FindXenomai.cmake

### DIFF
--- a/cmake/Modules/FindXenomai.cmake
+++ b/cmake/Modules/FindXenomai.cmake
@@ -166,6 +166,8 @@ find_package_handle_standard_args(Xenomai DEFAULT_MSG
   Xenomai_LIBRARY_XENOMAI
   Xenomai_LIBRARY_RTDK
   )
+  
+set(Xenomai_FOUND ${XENOMAI_FOUND}) # Set appropriately cased variable
 
 if(Xenomai_LIBRARY_XENOMAI AND Xenomai_LIBRARY_NATIVE) 
   message(STATUS "Xenomai Native skin found")


### PR DESCRIPTION
find_package_handle_standard_args generates all caps variables (XENOMAI_FOUND), while this script is expected to create Xenomai_FOUND.

This changeset creates the appropriately cased variable, but does not unset the all-caps variant for backwards-compatibility reasons (I typically unset it on new modules).
