### PR TITLE
Add CMake searcher for DepthSenseSDK.

### DIFF
--- a/cmake/Modules/FindDepthSenseSDK.cmake
+++ b/cmake/Modules/FindDepthSenseSDK.cmake
@@ -2,9 +2,10 @@
 #
 #  Once done these CMake variables are going to be set:
 #
-#       DepthSenseSDK_FOUND - system has DepthSenseSDK
-#       DepthSenseSDK_INCLUDE_DIR - the DepthSenseSDK include directories
-#       DepthSenseSDK_LIBRARIES - link these to use DepthSenseSDK
+#       DepthSenseSDK_FOUND - defined as TRUE if system has DepthSenseSDK, FALSE
+#           otherwise
+#       DepthSenseSDK_INCLUDE_DIR - DepthSenseSDK include directory
+#       DepthSenseSDK_LIBRARIES - DepthSenseSDK libraries
 
 
 if (WIN32)
@@ -34,7 +35,7 @@ else (DepthSenseSDK_INCLUDE_DIR AND DepthSenseSDK_LIBRARIES)
     set (DepthSenseSDK_FOUND OFF)
 endif (DepthSenseSDK_INCLUDE_DIR AND DepthSenseSDK_LIBRARIES)
 
-mark_as_advanced (DepthSenseSDK_FOUND)
+mark_as_advanced (DepthSenseSDK_LOCATION_GUESS)
 if(DepthSenseSDK_FOUND)
     include_directories(${DepthSenseSDK_INCLUDE_DIR})
 else()

--- a/cmake/Modules/FindDepthSenseSDK.cmake
+++ b/cmake/Modules/FindDepthSenseSDK.cmake
@@ -1,0 +1,43 @@
+# - Find the DepthSenseSDK includes and libraries.
+#
+#  Once done these CMake variables are going to be set:
+#
+#       DepthSenseSDK_FOUND - system has DepthSenseSDK
+#       DepthSenseSDK_INCLUDE_DIR - the DepthSenseSDK include directories
+#       DepthSenseSDK_LIBRARIES - link these to use DepthSenseSDK
+
+
+if (WIN32)
+    if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(PROGRAM_FILES_PATH $ENV{PROGRAMW6432})
+    else ()
+        set(PROGRAM_FILES_PATH $ENV{PROGRAMFILES})
+    endif()
+
+    set (DepthSenseSDK_LOCATION_GUESS "${PROGRAM_FILES_PATH}/SoftKinetic/DepthSense")
+else (WIN32)
+    set (DepthSenseSDK_LOCATION_GUESS "/opt/softkinetic/DepthSenseSDK")
+endif (WIN32)
+
+find_path (DepthSenseSDK_INCLUDE_DIR DepthSense.hxx
+    PATHS "${DepthSenseSDK_LOCATION_GUESS}/include/"
+    )
+
+find_library (DepthSenseSDK_LIBRARIES
+    NAMES DepthSense
+    PATHS "${DepthSenseSDK_LOCATION_GUESS}/lib"
+)
+
+if (DepthSenseSDK_INCLUDE_DIR AND DepthSenseSDK_LIBRARIES)
+    set (DepthSenseSDK_FOUND ON)
+else (DepthSenseSDK_INCLUDE_DIR AND DepthSenseSDK_LIBRARIES)
+    set (DepthSenseSDK_FOUND OFF)
+endif (DepthSenseSDK_INCLUDE_DIR AND DepthSenseSDK_LIBRARIES)
+
+mark_as_advanced (DepthSenseSDK_FOUND)
+if(DepthSenseSDK_FOUND)
+    include_directories(${DepthSenseSDK_INCLUDE_DIR})
+else()
+    message(STATUS "DepthSenseSDK not found!")
+endif(DepthSenseSDK_FOUND)
+


### PR DESCRIPTION
Adds CMake module for searching for DepthSenseSDK includes and libraries.

**What the heck is that?**
DepthSenseSDK --- product of SoftKinetic, developed as an interface for their stereo-cameras.  Those are use by at least couple of ROS users I know. 

Oh, besides, it's also released for [Windows](http://www.softkinetic.com/Support/Download), so, adding relevant searcher rules. 
